### PR TITLE
fix: resolve REVM version conflict by upgrading reth to v1.10.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,10 +47,10 @@ bitvec = "1.0"
 
 # Storage
 rocksdb = { version = "0.21", default-features = false, features = ["lz4"] }
-reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", default-features = false, features = ["mdbx"] }
-reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-libmdbx = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", features = ["return-borrowed"] }
+reth-db = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0", default-features = false, features = ["mdbx"] }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-codecs = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-libmdbx = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0", features = ["return-borrowed"] }
 
 # Networking
 futures = "0.3"

--- a/crates/mempool/Cargo.toml
+++ b/crates/mempool/Cargo.toml
@@ -7,14 +7,14 @@ license.workspace = true
 repository.workspace = true
 
 [dependencies]
-# Reth transaction pool and primitives (matching workspace v1.9.3)
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
-reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+# Reth transaction pool and primitives (matching workspace v1.10.0)
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-storage-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
+reth-chainspec = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0" }
 
-# Ethereum types (alloy suite - reth 1.9.3 uses alloy 1.x)
+# Ethereum types (alloy suite - reth 1.10.0 uses alloy 1.x)
 alloy-primitives = "1"
 alloy-eips = "1"
 alloy-consensus = "1"
@@ -35,5 +35,5 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", features = ["test-utils"] }
-reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", features = ["test-utils"] }
+reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0", features = ["test-utils"] }
+reth-provider = { git = "https://github.com/paradigmxyz/reth", tag = "v1.10.0", features = ["test-utils"] }


### PR DESCRIPTION
## Summary

This PR resolves the REVM version conflict between the `execution` and `mempool` crates.

### Problem

- `execution` crate uses `revm 33.1.0`
- `mempool` (via reth v1.9.3) pulls `revm 31.0.2`
- Multiple revm family crates had dual versions causing potential type incompatibilities

### Solution

Upgraded all reth dependencies from `v1.9.3` to `v1.10.0`:
- reth v1.10.0 uses revm 33.1.0, matching the execution crate

### Changes

- Updated `Cargo.toml` (workspace): reth-db, reth-db-api, reth-codecs, reth-libmdbx
- Updated `crates/mempool/Cargo.toml`: reth-transaction-pool, reth-primitives, reth-primitives-traits, reth-storage-api, reth-chainspec

### Verification

- [x] `cargo build` passes
- [x] `cargo test` passes (all 433 tests)
- [x] `cargo tree --duplicates | grep revm` returns empty (no duplicates)

Closes #29