### PR TITLE
fix: add cleanup logic to prevent unbounded HashMap growth

### DIFF
--- a/crates/data-chain/src/primary/state.rs
+++ b/crates/data-chain/src/primary/state.rs
@@ -447,7 +447,8 @@ impl PrimaryState {
         }
 
         // Remove validators with no remaining equivocation records
-        self.equivocations.retain(|_, positions| !positions.is_empty());
+        self.equivocations
+            .retain(|_, positions| !positions.is_empty());
     }
 
     /// Cleanup available batches that are no longer needed.
@@ -458,8 +459,12 @@ impl PrimaryState {
     ///
     /// # Arguments
     /// * `referenced_batches` - Set of batch hashes that are still referenced
-    pub fn cleanup_available_batches(&mut self, referenced_batches: &std::collections::HashSet<Hash>) {
-        self.available_batches.retain(|hash| referenced_batches.contains(hash));
+    pub fn cleanup_available_batches(
+        &mut self,
+        referenced_batches: &std::collections::HashSet<Hash>,
+    ) {
+        self.available_batches
+            .retain(|hash| referenced_batches.contains(hash));
     }
 
     /// Get all batch hashes currently referenced by pending or attested Cars.
@@ -514,14 +519,12 @@ impl PrimaryState {
         const STALE_TIMEOUT: Duration = Duration::from_secs(300); // 5 minutes
 
         // Cleanup old pending cars
-        self.pending_cars.retain(|_, pending| {
-            pending.created_at.elapsed() < STALE_TIMEOUT
-        });
+        self.pending_cars
+            .retain(|_, pending| pending.created_at.elapsed() < STALE_TIMEOUT);
 
         // Cleanup old cars awaiting batches
-        self.cars_awaiting_batches.retain(|_, awaiting| {
-            awaiting.requested_at.elapsed() < STALE_TIMEOUT
-        });
+        self.cars_awaiting_batches
+            .retain(|_, awaiting| awaiting.requested_at.elapsed() < STALE_TIMEOUT);
     }
 
     /// Perform full memory cleanup.

--- a/crates/storage/src/memory.rs
+++ b/crates/storage/src/memory.rs
@@ -400,7 +400,7 @@ impl DclStore for InMemoryStore {
                 }
             }
             // Also keep references from pending cuts
-            for (_, cut) in &state.pending {
+            for cut in state.pending.values() {
                 for car in cut.cars.values() {
                     referenced_car_hashes.insert(car.hash());
                 }
@@ -423,7 +423,7 @@ impl DclStore for InMemoryStore {
         let mut referenced_batch_hashes = std::collections::HashSet::new();
         {
             let state = self.car_state.read();
-            for (_, car) in &state.cars {
+            for car in state.cars.values() {
                 let car_hash = car.hash();
                 if referenced_car_hashes.contains(&car_hash) {
                     // This car is referenced, keep its batches


### PR DESCRIPTION
## Summary
- Add cleanup methods to PrimaryState for `equivocations` and `available_batches` HashMaps
- Enhance `InMemoryStore.prune_before()` to also prune Cars, Attestations, and Batches
- Add retention-based equivocation cleanup (keeps last 1000 heights)
- Add timeout-based pending data cleanup (removes entries older than 5 minutes)
- Add `full_cleanup()` method for comprehensive memory management

## Problem
Issue #31 identified unbounded HashMap growth in the consensus state management that could lead to memory leaks over time:
- `equivocations` HashMap never cleaned up
- `available_batches` HashSet only grows, never shrinks
- `InMemoryStore.prune_before()` only pruned Cuts, leaving orphaned Cars, Attestations, and Batches

## Solution
**PrimaryState cleanup methods:**
- `cleanup_stale_equivocations(retention_heights)` - removes old position data
- `cleanup_available_batches(referenced)` - removes unreferenced batch hashes
- `cleanup_stale_pending_data()` - timeout-based cleanup for pending cars
- `get_referenced_batch_hashes()` - helper to determine which batches are still needed
- `full_cleanup()` - comprehensive cleanup method

**InMemoryStore enhanced pruning:**
- Step 1: Collect Car hashes referenced by retained Cuts
- Step 2: Prune old finalized Cuts
- Step 3: Collect batch hashes referenced by retained Cars
- Step 4: Prune unreferenced Cars
- Step 5: Prune unreferenced Attestations
- Step 6: Prune unreferenced Batches

## Test plan
- [x] All 433+ existing tests pass
- [x] `test_prune` storage test verifies pruning behavior

Closes #31