### PR TITLE
fix: implement CAR request response handler in Primary

### DIFF
--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -293,7 +293,7 @@ impl PrimaryNetwork for TcpPrimaryNetwork {
     async fn send_attestation(&self, proposer: ValidatorId, attestation: &Attestation) {
         debug!("Sending attestation to {:?}", proposer);
         let msg = NetworkMessage::Dcl(Box::new(DclMessage::Attestation(attestation.clone())));
-        if let Err(e) = self.send_to(proposer, &msg).await {
+        if let Err(e) = TcpPrimaryNetwork::send_to(self, proposer, &msg).await {
             warn!("Failed to send attestation: {}", e);
         }
     }
@@ -301,6 +301,14 @@ impl PrimaryNetwork for TcpPrimaryNetwork {
     async fn broadcast(&self, message: &DclMessage) {
         let msg = NetworkMessage::Dcl(Box::new(message.clone()));
         TcpPrimaryNetwork::broadcast(self, &msg).await;
+    }
+
+    async fn send_to(&self, peer: ValidatorId, message: &DclMessage) {
+        debug!("Sending message to peer {:?}", peer);
+        let msg = NetworkMessage::Dcl(Box::new(message.clone()));
+        if let Err(e) = TcpPrimaryNetwork::send_to(self, peer, &msg).await {
+            warn!("Failed to send message to peer {:?}: {}", peer, e);
+        }
     }
 }
 

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -552,4 +552,8 @@ impl cipherbft_data_chain::primary::PrimaryNetwork for TcpPrimaryNetworkAdapter 
     async fn broadcast(&self, message: &DclMessage) {
         self.network.broadcast(message).await;
     }
+
+    async fn send_to(&self, peer: ValidatorId, message: &DclMessage) {
+        self.network.send_to(peer, message).await;
+    }
 }


### PR DESCRIPTION
## Summary
- Add `send_to` method to `PrimaryNetwork` trait for point-to-point communication
- Implement CarRequest handler that looks up CAR from storage and sends CarResponse back to the requester
- Update all `PrimaryNetwork` implementations (`TcpPrimaryNetwork`, `TcpPrimaryNetworkAdapter`, `MockNetwork`)

## Test plan
- [x] All 106 data-chain tests pass
- [x] All 19 node tests pass
- [x] Full build successful

Closes #46