### PR TITLE
feat: add configurable cleanup thresholds

### DIFF
--- a/crates/data-chain/src/primary/config.rs
+++ b/crates/data-chain/src/primary/config.rs
@@ -21,6 +21,11 @@ pub struct PrimaryConfig {
     pub max_empty_cars: u32,
     /// Number of workers per validator (default: 1)
     pub worker_count: u8,
+    /// Number of heights to retain equivocation data (default: 1000).
+    ///
+    /// Higher values preserve forensic evidence longer for slashing proofs,
+    /// at the cost of increased memory usage.
+    pub equivocation_retention: u64,
 }
 
 impl PrimaryConfig {
@@ -34,6 +39,7 @@ impl PrimaryConfig {
             attestation_timeout_max: Duration::from_millis(5000),
             max_empty_cars: 3,
             worker_count: 1,
+            equivocation_retention: 1000,
         }
     }
 
@@ -61,6 +67,12 @@ impl PrimaryConfig {
         self.worker_count = count;
         self
     }
+
+    /// Set equivocation retention (number of heights to keep equivocation data)
+    pub fn with_equivocation_retention(mut self, retention: u64) -> Self {
+        self.equivocation_retention = retention;
+        self
+    }
 }
 
 impl std::fmt::Debug for PrimaryConfig {
@@ -72,6 +84,7 @@ impl std::fmt::Debug for PrimaryConfig {
             .field("attestation_timeout_max", &self.attestation_timeout_max)
             .field("max_empty_cars", &self.max_empty_cars)
             .field("worker_count", &self.worker_count)
+            .field("equivocation_retention", &self.equivocation_retention)
             .finish()
     }
 }

--- a/crates/data-chain/src/primary/core.rs
+++ b/crates/data-chain/src/primary/core.rs
@@ -259,7 +259,7 @@ mod tests {
 
         let our_id = validator_id_from_bls_pubkey(&keypairs[0].public_key);
         let core = Core::new(our_id, keypairs[0].clone(), validator_pubkeys);
-        let state = PrimaryState::new(our_id);
+        let state = PrimaryState::new(our_id, 1000);
 
         (core, keypairs, state)
     }

--- a/crates/data-chain/src/primary/mod.rs
+++ b/crates/data-chain/src/primary/mod.rs
@@ -110,7 +110,7 @@ impl PrimaryDcl {
         let cut_former = cut_former::CutFormer::new(sorted_validators.clone());
 
         // Create state
-        let state = state::PrimaryState::new(our_id);
+        let state = state::PrimaryState::new(our_id, config.equivocation_retention);
 
         Self {
             our_id,

--- a/crates/data-chain/src/primary/runner.rs
+++ b/crates/data-chain/src/primary/runner.rs
@@ -241,7 +241,7 @@ impl Primary {
         event_sender: mpsc::Sender<PrimaryEvent>,
         storage: Option<Arc<dyn CarStore>>,
     ) -> Self {
-        let state = PrimaryState::new(config.validator_id);
+        let state = PrimaryState::new(config.validator_id, config.equivocation_retention);
 
         let proposer = Proposer::new(
             config.validator_id,

--- a/crates/data-chain/tests/crash_recovery.rs
+++ b/crates/data-chain/tests/crash_recovery.rs
@@ -143,7 +143,7 @@ async fn test_primary_state_restoration() {
     let recovered = recovery.recover().await.unwrap();
 
     // Restore to PrimaryState
-    let mut state = PrimaryState::new(our_id);
+    let mut state = PrimaryState::new(our_id, 1000);
     state.current_height = recovered.pipeline_height.unwrap_or(0);
 
     // Convert WAL pipeline stage to state pipeline stage
@@ -226,7 +226,7 @@ async fn test_timeout_preservation_recovery() {
     assert_eq!(recovered_car.position, 5);
 
     // Restore to PrimaryState
-    let mut state = PrimaryState::new(our_id);
+    let mut state = PrimaryState::new(our_id, 1000);
 
     for (vid, car, att) in recovered.preserved_attested_cars {
         state.preserved_attested_cars.insert(vid, (car, att));


### PR DESCRIPTION
## Summary
- Add `pending_cuts_retention` and `decided_retention` fields to `HostConfig`
- Add `equivocation_retention` field to `PrimaryConfig`
- Update cleanup methods to use configurable values instead of hardcoded constants

Closes #52