### PR TITLE
feat: implement genesis state initialization

### DIFF
--- a/crates/execution/src/genesis.rs
+++ b/crates/execution/src/genesis.rs
@@ -491,10 +491,8 @@ mod tests {
 
         // Verify validator account was created
         let account = provider.get_account(validator.address).unwrap().unwrap();
-        assert_eq!(
-            account.balance,
-            U256::from(64_000_000_000_000_000_000u128)
-        ); // 2x stake
+        assert_eq!(account.balance, U256::from(64_000_000_000_000_000_000u128));
+        // 2x stake
     }
 
     #[test]
@@ -521,8 +519,14 @@ mod tests {
 
         // Verify each validator
         for (i, validator) in validators.iter().enumerate() {
-            assert_eq!(read_validator_address(&*provider, i).unwrap(), validator.address);
-            assert_eq!(read_validator_stake(&*provider, i).unwrap(), validator.staked_amount);
+            assert_eq!(
+                read_validator_address(&*provider, i).unwrap(),
+                validator.address
+            );
+            assert_eq!(
+                read_validator_stake(&*provider, i).unwrap(),
+                validator.staked_amount
+            );
         }
     }
 
@@ -559,9 +563,7 @@ mod tests {
         assert!(stored_code.is_some());
 
         // Verify storage was set
-        let storage_value = provider
-            .get_storage(contract_addr, U256::ZERO)
-            .unwrap();
+        let storage_value = provider.get_storage(contract_addr, U256::ZERO).unwrap();
         assert_eq!(storage_value, U256::from(42));
     }
 
@@ -593,13 +595,22 @@ mod tests {
 
         // Read voting powers (should be in basis points: 2500, 5000, 2500)
         let power_0 = provider
-            .get_storage(STAKING_PRECOMPILE_ADDRESS, staking_slots::VALIDATORS_START + U256::from(2))
+            .get_storage(
+                STAKING_PRECOMPILE_ADDRESS,
+                staking_slots::VALIDATORS_START + U256::from(2),
+            )
             .unwrap();
         let power_1 = provider
-            .get_storage(STAKING_PRECOMPILE_ADDRESS, staking_slots::VALIDATORS_START + U256::from(5))
+            .get_storage(
+                STAKING_PRECOMPILE_ADDRESS,
+                staking_slots::VALIDATORS_START + U256::from(5),
+            )
             .unwrap();
         let power_2 = provider
-            .get_storage(STAKING_PRECOMPILE_ADDRESS, staking_slots::VALIDATORS_START + U256::from(8))
+            .get_storage(
+                STAKING_PRECOMPILE_ADDRESS,
+                staking_slots::VALIDATORS_START + U256::from(8),
+            )
             .unwrap();
 
         assert_eq!(power_0, U256::from(2500)); // 25%

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -67,6 +67,10 @@ pub use evm::{
     CipherBftEvmConfig, TransactionResult, CIPHERBFT_CHAIN_ID, DEFAULT_BASE_FEE_PER_GAS,
     DEFAULT_BLOCK_GAS_LIMIT, MIN_STAKE_AMOUNT, UNBONDING_PERIOD_SECONDS,
 };
+pub use genesis::{
+    read_total_staked, read_validator_address, read_validator_count, read_validator_stake,
+    GenesisInitializer,
+};
 pub use mpt::{compute_state_root, compute_state_root_from_entries, compute_storage_root};
 pub use precompiles::{
     CipherBftPrecompileProvider, StakingPrecompile, StakingState, ValidatorInfo,
@@ -75,10 +79,6 @@ pub use precompiles::{
 pub use receipts::{
     aggregate_bloom, compute_logs_bloom_from_transactions, compute_receipts_root,
     compute_transactions_root, logs_bloom,
-};
-pub use genesis::{
-    read_total_staked, read_validator_address, read_validator_count, read_validator_stake,
-    GenesisInitializer,
 };
 pub use rlp::{rlp_encode_account, rlp_encode_storage_value, RlpAccount, KECCAK_EMPTY};
 pub use state::StateManager;


### PR DESCRIPTION
## Summary
- Implement `GenesisInitializer<P: Provider>` for EVM state initialization from genesis configuration
- Initialize account balances, nonces, and storage from `alloc` section
- Deploy contract bytecode with proper code hash computation
- Bootstrap staking precompile (0x100) with sequential storage layout
- Calculate validator voting power in basis points

## Implementation Details

### Staking Precompile Storage Layout (0x100)
```
Slot 0: version (uint256) = 1
Slot 1: validatorCount (uint256)
Slot 2: totalStaked (uint256)
Slot 3+: Validator entries (3 slots each)
  - Slot +0: address (left-padded to 32 bytes)
  - Slot +1: stakedAmount (uint256)
  - Slot +2: votingPower (basis points, 10000 = 100%)
```

### New Public API
- `GenesisInitializer::new(provider)` - Create initializer
- `GenesisInitializer::initialize(genesis)` - Initialize EVM state
- `read_validator_count(provider)` - Query validator count
- `read_total_staked(provider)` - Query total staked amount
- `read_validator_stake(provider, index)` - Query validator stake
- `read_validator_address(provider, index)` - Query validator address

## Test Plan
- [x] Unit tests for single/multiple validator initialization
- [x] Unit tests for contract deployment with storage
- [x] Unit tests for voting power calculation
- [x] Integration with existing execution tests (135 tests pass)

Closes #73