### PR TITLE
feat(rpc): implement provider-based RPC storage adapter

### DIFF
--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -9,6 +9,7 @@ description = "CipherBFT JSON-RPC Server - Ethereum-compatible RPC interface"
 [dependencies]
 # Internal dependencies
 cipherbft-types = { path = "../types" }
+cipherbft-execution = { path = "../execution" }
 
 # Async runtime
 tokio = { workspace = true, features = ["full", "sync"] }

--- a/crates/rpc/src/adapters.rs
+++ b/crates/rpc/src/adapters.rs
@@ -11,27 +11,314 @@
 //! - Adapters translate between RPC types (alloy) and storage types
 //! - Actual storage backends (MDBX, in-memory) handle persistence
 //!
-//! # Future Work
+//! # Adapter Types
 //!
-//! These adapters will be fully implemented when:
-//! - Block/Transaction storage is added to cipherbft-storage
-//! - Mempool integration is completed
-//! - Execution layer (revm) integration is finalized
+//! - `ProviderBasedRpcStorage`: Real adapter using execution layer's Provider trait
+//! - `StubRpcStorage`: Placeholder for testing (block/transaction queries)
+//! - `StubMempoolApi`: Placeholder until mempool integration
+//! - `EvmExecutionApi`: Real execution adapter using revm (planned)
+//! - `StubNetworkApi`: Placeholder until P2P integration
 
 use alloy_primitives::{Address, Bytes, B256, U256};
 use alloy_rpc_types_eth::{Block, Filter, Log, Transaction, TransactionReceipt};
 use async_trait::async_trait;
+use cipherbft_execution::database::Provider;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use tracing::{debug, trace};
 
-use crate::error::RpcResult;
+use crate::error::{RpcError, RpcResult};
 use crate::traits::{
     BlockNumberOrTag, ExecutionApi, MempoolApi, NetworkApi, RpcStorage, SyncStatus,
 };
 
+/// Provider-based RPC storage adapter.
+///
+/// This adapter uses the execution layer's `Provider` trait to answer
+/// state queries (balance, code, storage, nonce). Block and transaction
+/// queries are still stubbed until block indexing is implemented.
+pub struct ProviderBasedRpcStorage<P: Provider> {
+    /// The underlying provider for state queries.
+    provider: Arc<P>,
+    /// Chain ID for this network.
+    /// Reserved for future use in eth_chainId responses.
+    #[allow(dead_code)]
+    chain_id: u64,
+    /// Latest known block number (updated by consensus).
+    latest_block: AtomicU64,
+    /// Sync status tracking.
+    sync_state: std::sync::RwLock<SyncStateTracker>,
+}
+
+/// Internal sync state tracker.
+#[derive(Debug, Clone, Default)]
+struct SyncStateTracker {
+    /// Whether we're currently syncing.
+    is_syncing: bool,
+    /// Block when sync started.
+    starting_block: u64,
+    /// Current block during sync.
+    current_block: u64,
+    /// Highest known block.
+    highest_block: u64,
+}
+
+impl<P: Provider> ProviderBasedRpcStorage<P> {
+    /// Create a new provider-based storage adapter.
+    pub fn new(provider: Arc<P>, chain_id: u64) -> Self {
+        Self {
+            provider,
+            chain_id,
+            latest_block: AtomicU64::new(0),
+            sync_state: std::sync::RwLock::new(SyncStateTracker::default()),
+        }
+    }
+
+    /// Update the latest block number (called by consensus layer).
+    pub fn set_latest_block(&self, block: u64) {
+        self.latest_block.store(block, Ordering::SeqCst);
+    }
+
+    /// Get the latest block number.
+    pub fn get_latest_block(&self) -> u64 {
+        self.latest_block.load(Ordering::SeqCst)
+    }
+
+    /// Update sync status (called by sync service).
+    pub fn set_syncing(&self, starting: u64, current: u64, highest: u64) {
+        let mut state = self.sync_state.write().expect("sync_state lock poisoned");
+        state.is_syncing = true;
+        state.starting_block = starting;
+        state.current_block = current;
+        state.highest_block = highest;
+    }
+
+    /// Mark sync as complete.
+    pub fn set_synced(&self) {
+        let mut state = self.sync_state.write().expect("sync_state lock poisoned");
+        state.is_syncing = false;
+    }
+
+    /// Resolve block number from tag.
+    fn resolve_block_number(&self, block: BlockNumberOrTag) -> u64 {
+        match block {
+            BlockNumberOrTag::Number(n) => n,
+            BlockNumberOrTag::Latest
+            | BlockNumberOrTag::Safe
+            | BlockNumberOrTag::Finalized
+            | BlockNumberOrTag::Pending => self.latest_block.load(Ordering::SeqCst),
+            BlockNumberOrTag::Earliest => 0,
+        }
+    }
+}
+
+#[async_trait]
+impl<P: Provider + 'static> RpcStorage for ProviderBasedRpcStorage<P> {
+    async fn get_block_by_number(
+        &self,
+        number: BlockNumberOrTag,
+        _full_transactions: bool,
+    ) -> RpcResult<Option<Block>> {
+        let resolved = self.resolve_block_number(number);
+        trace!(
+            "ProviderBasedRpcStorage::get_block_by_number({:?} -> {})",
+            number,
+            resolved
+        );
+        // Block indexing not yet implemented - return None
+        // TODO: Implement when block storage is added
+        Ok(None)
+    }
+
+    async fn get_block_by_hash(
+        &self,
+        hash: B256,
+        _full_transactions: bool,
+    ) -> RpcResult<Option<Block>> {
+        trace!("ProviderBasedRpcStorage::get_block_by_hash({})", hash);
+        // Block indexing not yet implemented - return None
+        // TODO: Implement when block storage is added
+        Ok(None)
+    }
+
+    async fn get_transaction_by_hash(&self, hash: B256) -> RpcResult<Option<Transaction>> {
+        trace!("ProviderBasedRpcStorage::get_transaction_by_hash({})", hash);
+        // Transaction indexing not yet implemented - return None
+        // TODO: Implement when transaction storage is added
+        Ok(None)
+    }
+
+    async fn get_transaction_receipt(&self, hash: B256) -> RpcResult<Option<TransactionReceipt>> {
+        trace!("ProviderBasedRpcStorage::get_transaction_receipt({})", hash);
+        // Receipt storage not yet implemented - return None
+        // TODO: Implement when receipt storage is added
+        Ok(None)
+    }
+
+    async fn get_logs(&self, filter: Filter) -> RpcResult<Vec<Log>> {
+        trace!("ProviderBasedRpcStorage::get_logs({:?})", filter);
+        // Log indexing not yet implemented - return empty
+        // TODO: Implement when log indexing is added
+        Ok(Vec::new())
+    }
+
+    async fn latest_block_number(&self) -> RpcResult<u64> {
+        trace!("ProviderBasedRpcStorage::latest_block_number");
+        Ok(self.latest_block.load(Ordering::SeqCst))
+    }
+
+    async fn sync_status(&self) -> RpcResult<SyncStatus> {
+        trace!("ProviderBasedRpcStorage::sync_status");
+        let state = self.sync_state.read().expect("sync_state lock poisoned");
+        if state.is_syncing {
+            Ok(SyncStatus::Syncing {
+                starting_block: state.starting_block,
+                current_block: state.current_block,
+                highest_block: state.highest_block,
+            })
+        } else {
+            Ok(SyncStatus::NotSyncing)
+        }
+    }
+
+    async fn get_balance(&self, address: Address, block: BlockNumberOrTag) -> RpcResult<U256> {
+        let _block_num = self.resolve_block_number(block);
+        trace!(
+            "ProviderBasedRpcStorage::get_balance({}, {:?})",
+            address,
+            block
+        );
+
+        // Query account from provider
+        // Note: Currently queries latest state; historical state requires state archival
+        match self.provider.get_account(address) {
+            Ok(Some(account)) => {
+                debug!("Found account {} with balance {}", address, account.balance);
+                Ok(account.balance)
+            }
+            Ok(None) => {
+                trace!("Account {} not found, returning zero balance", address);
+                Ok(U256::ZERO)
+            }
+            Err(e) => {
+                debug!("Error getting account {}: {}", address, e);
+                Err(RpcError::Storage(e.to_string()))
+            }
+        }
+    }
+
+    async fn get_code(&self, address: Address, block: BlockNumberOrTag) -> RpcResult<Bytes> {
+        let _block_num = self.resolve_block_number(block);
+        trace!(
+            "ProviderBasedRpcStorage::get_code({}, {:?})",
+            address,
+            block
+        );
+
+        // First get account to find code hash
+        match self.provider.get_account(address) {
+            Ok(Some(account)) => {
+                // Check if account has code (not KECCAK_EMPTY)
+                let keccak_empty = B256::from(cipherbft_execution::KECCAK_EMPTY);
+                if account.code_hash == keccak_empty || account.code_hash == B256::ZERO {
+                    trace!("Account {} has no code", address);
+                    return Ok(Bytes::new());
+                }
+
+                // Get the actual bytecode
+                match self.provider.get_code(account.code_hash) {
+                    Ok(Some(bytecode)) => {
+                        let bytes = bytecode.bytes_slice().to_vec();
+                        debug!("Found code for {} ({} bytes)", address, bytes.len());
+                        Ok(Bytes::from(bytes))
+                    }
+                    Ok(None) => {
+                        trace!("Code hash {} not found for {}", account.code_hash, address);
+                        Ok(Bytes::new())
+                    }
+                    Err(e) => {
+                        debug!("Error getting code for {}: {}", address, e);
+                        Err(RpcError::Storage(e.to_string()))
+                    }
+                }
+            }
+            Ok(None) => {
+                trace!("Account {} not found", address);
+                Ok(Bytes::new())
+            }
+            Err(e) => {
+                debug!("Error getting account {}: {}", address, e);
+                Err(RpcError::Storage(e.to_string()))
+            }
+        }
+    }
+
+    async fn get_storage_at(
+        &self,
+        address: Address,
+        slot: U256,
+        block: BlockNumberOrTag,
+    ) -> RpcResult<B256> {
+        let _block_num = self.resolve_block_number(block);
+        trace!(
+            "ProviderBasedRpcStorage::get_storage_at({}, {}, {:?})",
+            address,
+            slot,
+            block
+        );
+
+        match self.provider.get_storage(address, slot) {
+            Ok(value) => {
+                let result = B256::from(value.to_be_bytes::<32>());
+                if !value.is_zero() {
+                    debug!("Found storage {}[{}] = {}", address, slot, value);
+                }
+                Ok(result)
+            }
+            Err(e) => {
+                debug!("Error getting storage {}[{}]: {}", address, slot, e);
+                Err(RpcError::Storage(e.to_string()))
+            }
+        }
+    }
+
+    async fn get_transaction_count(
+        &self,
+        address: Address,
+        block: BlockNumberOrTag,
+    ) -> RpcResult<u64> {
+        let _block_num = self.resolve_block_number(block);
+        trace!(
+            "ProviderBasedRpcStorage::get_transaction_count({}, {:?})",
+            address,
+            block
+        );
+
+        match self.provider.get_account(address) {
+            Ok(Some(account)) => {
+                debug!("Found account {} with nonce {}", address, account.nonce);
+                Ok(account.nonce)
+            }
+            Ok(None) => {
+                trace!("Account {} not found, returning nonce 0", address);
+                Ok(0)
+            }
+            Err(e) => {
+                debug!("Error getting account {}: {}", address, e);
+                Err(RpcError::Storage(e.to_string()))
+            }
+        }
+    }
+}
+
+// ============================================================================
+// Stub Implementations (for testing and features not yet integrated)
+// ============================================================================
+
 /// Stub RPC storage adapter.
 ///
 /// This adapter provides placeholder implementations for RPC storage operations.
-/// Replace with actual storage integration when block/tx storage is available.
+/// Used for testing or when the real storage backend is not available.
 pub struct StubRpcStorage {
     /// Latest block number (for testing).
     latest_block: u64,
@@ -69,7 +356,6 @@ impl RpcStorage for StubRpcStorage {
         _full_transactions: bool,
     ) -> RpcResult<Option<Block>> {
         trace!("StubRpcStorage::get_block_by_number({:?})", number);
-        // Return None for now - no blocks stored
         Ok(None)
     }
 
@@ -104,7 +390,6 @@ impl RpcStorage for StubRpcStorage {
 
     async fn sync_status(&self) -> RpcResult<SyncStatus> {
         trace!("StubRpcStorage::sync_status");
-        // For now, always report as synced
         Ok(SyncStatus::NotSyncing)
     }
 
@@ -305,6 +590,126 @@ impl NetworkApi for StubNetworkApi {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cipherbft_execution::database::InMemoryProvider;
+
+    #[tokio::test]
+    async fn test_provider_based_storage_empty() {
+        let provider = Arc::new(InMemoryProvider::new());
+        let storage = ProviderBasedRpcStorage::new(provider, 85300);
+
+        // Should return zero for non-existent accounts
+        let balance = storage
+            .get_balance(Address::ZERO, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(balance, U256::ZERO);
+
+        let nonce = storage
+            .get_transaction_count(Address::ZERO, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(nonce, 0);
+
+        let code = storage
+            .get_code(Address::ZERO, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert!(code.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_provider_based_storage_with_account() {
+        use cipherbft_execution::database::Account;
+
+        let provider = Arc::new(InMemoryProvider::new());
+
+        // Create an account with balance
+        let addr = Address::repeat_byte(0x42);
+        let account = Account {
+            nonce: 5,
+            balance: U256::from(1000000000000000000u128), // 1 ETH
+            code_hash: B256::ZERO,
+            storage_root: B256::ZERO,
+        };
+        provider.set_account(addr, account).unwrap();
+
+        let storage = ProviderBasedRpcStorage::new(provider, 85300);
+
+        // Should return the account balance
+        let balance = storage
+            .get_balance(addr, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(balance, U256::from(1000000000000000000u128));
+
+        // Should return the account nonce
+        let nonce = storage
+            .get_transaction_count(addr, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(nonce, 5);
+    }
+
+    #[tokio::test]
+    async fn test_provider_based_storage_with_storage() {
+        let provider = Arc::new(InMemoryProvider::new());
+
+        let addr = Address::repeat_byte(0x42);
+        let slot = U256::from(1);
+        let value = U256::from(42);
+
+        provider.set_storage(addr, slot, value).unwrap();
+
+        let storage = ProviderBasedRpcStorage::new(provider, 85300);
+
+        let result = storage
+            .get_storage_at(addr, slot, BlockNumberOrTag::Latest)
+            .await
+            .unwrap();
+        assert_eq!(result, B256::from(value.to_be_bytes::<32>()));
+    }
+
+    #[tokio::test]
+    async fn test_provider_based_storage_latest_block() {
+        let provider = Arc::new(InMemoryProvider::new());
+        let storage = ProviderBasedRpcStorage::new(provider, 85300);
+
+        assert_eq!(storage.latest_block_number().await.unwrap(), 0);
+
+        storage.set_latest_block(100);
+        assert_eq!(storage.latest_block_number().await.unwrap(), 100);
+    }
+
+    #[tokio::test]
+    async fn test_provider_based_storage_sync_status() {
+        let provider = Arc::new(InMemoryProvider::new());
+        let storage = ProviderBasedRpcStorage::new(provider, 85300);
+
+        // Initially not syncing
+        let status = storage.sync_status().await.unwrap();
+        assert!(matches!(status, SyncStatus::NotSyncing));
+
+        // Set syncing
+        storage.set_syncing(0, 50, 100);
+        let status = storage.sync_status().await.unwrap();
+        match status {
+            SyncStatus::Syncing {
+                starting_block,
+                current_block,
+                highest_block,
+            } => {
+                assert_eq!(starting_block, 0);
+                assert_eq!(current_block, 50);
+                assert_eq!(highest_block, 100);
+            }
+            _ => panic!("Expected Syncing status"),
+        }
+
+        // Mark as synced
+        storage.set_synced();
+        let status = storage.sync_status().await.unwrap();
+        assert!(matches!(status, SyncStatus::NotSyncing));
+    }
 
     #[tokio::test]
     async fn test_stub_storage() {


### PR DESCRIPTION
## Summary

- Add `ProviderBasedRpcStorage<P: Provider>` generic adapter connecting RPC layer to execution layer's Provider trait
- Implement real state queries: `get_balance`, `get_code`, `get_storage_at`, `get_transaction_count`
- Add block number tracking with `AtomicU64` (updated by consensus layer)
- Add sync status tracking with `RwLock<SyncStateTracker>`
- Block/transaction queries remain stubbed (awaiting block indexing in future issue)
- Add comprehensive tests for new adapter

## Test plan

- [x] All 58 RPC crate tests pass
- [x] `cargo clippy -p cipherbft-rpc` passes
- [x] `cargo fmt --check` passes

Closes #74