### PR TITLE
fix: add context to port binding errors

### DIFF
--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -206,7 +206,17 @@ where
             .max_connections(self.config.max_connections)
             .build(addr)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                format!(
+                    "Failed to bind HTTP RPC server to {}. \
+                     Port {} may already be in use. \
+                     Check with: lsof -i :{} (error: {})",
+                    addr,
+                    addr.port(),
+                    addr.port(),
+                    e
+                )
+            })?;
 
         let handle = server.start(module);
         Ok(handle)
@@ -223,7 +233,17 @@ where
             .ws_only()
             .build(addr)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| {
+                format!(
+                    "Failed to bind WebSocket RPC server to {}. \
+                     Port {} may already be in use. \
+                     Check with: lsof -i :{} (error: {})",
+                    addr,
+                    addr.port(),
+                    addr.port(),
+                    e
+                )
+            })?;
 
         let handle = server.start(module);
         Ok(handle)


### PR DESCRIPTION
## Summary

Add descriptive error context to all network binding operations to improve debuggability when ports are already in use.

Closes #87

## Changes

- Add `anyhow::Context` to primary network listener binding in `network.rs`
- Add context to consensus network spawn in `node.rs`
- Add context to HTTP and WebSocket RPC server binding in `server.rs`

## Before/After

**Before:**
```
Error: Address already in use (os error 48)
```

**After:**
```
Error: Failed to start primary network listener on 127.0.0.1:9000

Caused by:
    Failed to bind primary network listener to 127.0.0.1:9000. Port 9000 may already be in use. Check with: lsof -i :9000
```

## Test Plan

- [x] `cargo check` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy` passes