### PR TITLE
fix: find our address in sorted validator set

### DIFF
--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -366,7 +366,16 @@ impl Node {
             }
         }
         let ctx = create_context(chain_id, consensus_validators, None)?;
-        let our_address = ctx.validator_set().as_slice()[0].address;
+        // Find our own address in the sorted validator set by matching our validator ID.
+        // Note: The validator set is sorted by voting power (desc), then address (asc),
+        // so we cannot assume our position - we must search for ourselves.
+        let our_address = ctx
+            .validator_set()
+            .as_slice()
+            .iter()
+            .find(|v| v.address.0 == self.validator_id)
+            .expect("our validator must be in the validator set")
+            .address;
         let params = default_consensus_params(&ctx, our_address);
         let consensus_config = default_engine_config_single_part();
 


### PR DESCRIPTION
## Summary
- Fix invalid signature errors during testnet consensus by correctly finding our validator address in the sorted validator set

## Problem
The code incorrectly assumed that after creating the consensus context, the current node would be at index 0 of the validator set. However, `ConsensusValidatorSet::new()` sorts validators by voting power (desc), then by address (asc). With equal voting power, this meant all nodes thought they were the validator with the lowest address.

## Solution
Find our own address by matching `self.validator_id` instead of assuming index 0.

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` passes
- [x] `cargo clippy` passes
- [ ] Run `cipherd testnet start` and verify consensus proceeds without signature errors