### PR TITLE
fix: use correct round in LocallyProposedValue

### DIFF
--- a/crates/consensus/src/host.rs
+++ b/crates/consensus/src/host.rs
@@ -877,7 +877,7 @@ impl ValueBuilder for ChannelValueBuilder {
     async fn build_value(
         &self,
         height: ConsensusHeight,
-        _round: ConsensusRound,
+        round: ConsensusRound,
     ) -> Result<LocallyProposedValue<CipherBftContext>, ConsensusError> {
         // Wait for a cut at this height with timeout
         let timeout = Duration::from_secs(30);
@@ -908,11 +908,7 @@ impl ValueBuilder for ChannelValueBuilder {
                         .await
                         .insert(value_id.clone(), cut);
 
-                    return Ok(LocallyProposedValue::new(
-                        height,
-                        informalsystems_malachitebft_core_types::Round::new(0),
-                        value,
-                    ));
+                    return Ok(LocallyProposedValue::new(height, round, value));
                 }
 
                 // Log available heights on first wait (helpful for debugging)


### PR DESCRIPTION
Fixes proposal round mismatch causing consensus to ignore all proposals.

**Problem**: `build_value()` ignored the `round` parameter and always used `Round::new(0)`. When consensus requested a proposal at round 6+, the returned value had round 0, causing malachite to reject it with "Ignoring value for round 0, current round: 6".

**Solution**: Use the `round` parameter passed by consensus instead of hardcoding `Round::new(0)`.