### PR TITLE
refactor: demote verbose consensus logs to debug

### DIFF
--- a/crates/consensus/src/execution_handler.rs
+++ b/crates/consensus/src/execution_handler.rs
@@ -40,7 +40,7 @@ use async_trait::async_trait;
 use informalsystems_malachitebft_core_types::CommitCertificate;
 use informalsystems_malachitebft_sync::RawDecidedValue;
 use tokio::sync::{mpsc, RwLock};
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 use crate::context::CipherBftContext;
 use crate::error::ConsensusError;
@@ -240,7 +240,7 @@ impl<E: ExecutionCallback, R: ReceiptStore> DecisionHandler for ExecutingDecisio
     ) -> Result<(), ConsensusError> {
         let cut = value.into_cut();
 
-        info!(
+        debug!(
             height = height.0,
             cars = cut.cars.len(),
             "ExecutingDecisionHandler: Processing decided Cut"
@@ -249,7 +249,7 @@ impl<E: ExecutionCallback, R: ReceiptStore> DecisionHandler for ExecutingDecisio
         // Execute the Cut via callback
         match self.execution_callback.execute(height.0, &cut).await {
             Ok((state_root, gas_used)) => {
-                info!(
+                debug!(
                     height = height.0,
                     state_root = %state_root,
                     gas_used = gas_used,

--- a/crates/consensus/src/host.rs
+++ b/crates/consensus/src/host.rs
@@ -372,7 +372,7 @@ impl Actor for CipherBftHost {
                 tokio::spawn(async move {
                     match value_builder.build_value(height, round).await {
                         Ok(value) => {
-                            info!(
+                            debug!(
                                 parent: &span,
                                 height = height.0,
                                 "Built proposal value"

--- a/crates/data-chain/src/primary/runner.rs
+++ b/crates/data-chain/src/primary/runner.rs
@@ -450,7 +450,7 @@ impl Primary {
     async fn handle_command(&mut self, cmd: PrimaryCommand) {
         match cmd {
             PrimaryCommand::ConsensusDecided { height } => {
-                info!(
+                debug!(
                     height,
                     validator = %self.config.validator_id,
                     "Received consensus decision notification"

--- a/crates/node/src/execution_bridge.rs
+++ b/crates/node/src/execution_bridge.rs
@@ -14,7 +14,7 @@ use cipherbft_types::genesis::Genesis;
 use std::sync::Arc;
 use std::sync::RwLock as StdRwLock;
 use tokio::sync::RwLock;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 /// Bridge between consensus and execution layers
 ///
@@ -178,7 +178,7 @@ impl ExecutionBridge {
         &self,
         consensus_cut: cipherbft_data_chain::Cut,
     ) -> anyhow::Result<ExecutionResult> {
-        info!(
+        debug!(
             height = consensus_cut.height,
             cars = consensus_cut.cars.len(),
             "Executing Cut"
@@ -227,7 +227,7 @@ impl ExecutionBridge {
             *guard = new_block_hash;
         }
 
-        info!(
+        debug!(
             height = block_number,
             block_hash = %new_block_hash,
             parent_hash = %parent_hash,

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -806,7 +806,7 @@ impl Node {
                 Some(event) = primary_handle.recv_event() => {
                     match event {
                         PrimaryEvent::CutReady(cut) => {
-                            info!(
+                            debug!(
                                 "Cut ready at height {} with {} validators",
                                 cut.height,
                                 cut.validator_count()
@@ -839,7 +839,7 @@ impl Node {
 
                 // Consensus Decided events - execute the decided Cut
                 Some((height, cut)) = decided_rx.recv() => {
-                    info!(
+                    debug!(
                         "Consensus decided at height {} with {} cars",
                         height,
                         cut.cars.len()


### PR DESCRIPTION
## Summary
- Demote per-block/per-round consensus logs from `info!` to `debug!`
- Reduce log noise in production while keeping diagnostic info available

## Changes
| File | Log Message | Change |
|------|-------------|--------|
| `host.rs` | "Built proposal value" | info → debug |
| `execution_handler.rs` | "Processing decided Cut" | info → debug |
| `execution_handler.rs` | "Cut executed successfully" | info → debug |
| `node.rs` | "Cut ready at height..." | info → debug |
| `node.rs` | "Consensus decided at height..." | info → debug |
| `execution_bridge.rs` | "Executing Cut" | info → debug |
| `execution_bridge.rs` | "Block hash updated" | info → debug |
| `runner.rs` | "Received consensus decision notification" | info → debug |

## Rationale
- Canonical decision log "Consensus decided on value" remains at `info!`
- Epoch transitions remain at `info!`
- Vote extension logs already at `trace!` (no change)

## Test plan
- [x] Build passes
- [x] All tests pass