### PR TITLE
fix(node): enable execution layer in cmd_start for Blockscout sync

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -729,8 +729,9 @@ async fn cmd_start(
 
     info!("Starting node as validator {:?}", validator_id);
 
-    // Create node with keypairs and bootstrap validators from genesis
-    let mut node = Node::new(config, bls_keypair, ed25519_keypair)?;
+    // Create node with keypairs, enable execution layer, and bootstrap validators from genesis
+    let mut node = Node::new(config, bls_keypair, ed25519_keypair)?
+        .with_execution_layer_from_genesis(&genesis)?;
     node.bootstrap_validators_from_genesis(&genesis)?;
 
     // Create a supervisor for structured task management and graceful shutdown


### PR DESCRIPTION
## Summary

- Enable execution layer by default in `cmd_start` for production nodes
- Fixes Blockscout sync issue where `last_block_number` was null

## Problem

When running `cipherd start`, the execution bridge was never initialized. This caused:
- Only the `latest_block` counter to be updated, but no actual block data stored to MDBX
- `eth_getBlockByNumber` returning null for all blocks
- Blockscout unable to sync with the chain

## Solution

Add `.with_execution_layer_from_genesis(&genesis)?` call in `cmd_start()` to enable the execution layer, which:
- Executes transactions and stores blocks to MDBX
- Stores receipts for `eth_getBlockReceipts` support
- Enables proper RPC responses for block queries

## Test plan

- [x] `cargo check --package cipherd` passes
- [x] All 19 tests pass
- [ ] Manual verification: restart node and confirm Blockscout syncs