### PR TITLE
fix(rpc): enable serde feature for hex serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,10 +83,11 @@ tower-http = { version = "0.6", features = ["full"] }
 dashmap = "6.1"
 
 # Alloy types (v1.x for reth v1.10.0 compatibility)
+# IMPORTANT: serde feature required for proper hex serialization in JSON-RPC responses
 alloy-primitives = { version = "1", features = ["serde", "rlp"] }
 alloy-rpc-types = { version = "1" }
-alloy-rpc-types-eth = { version = "1" }
-alloy-consensus = { version = "1" }
+alloy-rpc-types-eth = { version = "1", features = ["serde"] }
+alloy-consensus = { version = "1", features = ["serde"] }
 
 # Networking
 futures = "0.3"


### PR DESCRIPTION
## Summary

- Enable `serde` feature for `alloy-rpc-types-eth` and `alloy-consensus` crates
- Fixes Blockscout sync error: `FunctionClauseError in EthereumJSONRPC.Block.do_elixir_to_params/1`

## Problem

Blockscout was failing to parse block responses with:
```
no function clause matching in EthereumJSONRPC.Block.do_elixir_to_params/1
```

The root cause was that alloy crates were serializing numeric fields as integers instead of hex strings:
- `"number" => 1038` instead of `"number" => "0x40e"`
- `"timestamp" => 1737779302` instead of `"timestamp" => "0x67948c16"`

Ethereum JSON-RPC spec requires all quantities to be hex-encoded strings with `0x` prefix.

## Solution

Enable the `serde` feature for alloy crates in `Cargo.toml`:
- `alloy-rpc-types-eth = { version = "1", features = ["serde"] }`
- `alloy-consensus = { version = "1", features = ["serde"] }`

This activates `#[serde(with = "alloy_serde::quantity")]` attributes that properly serialize numbers as hex strings.

## Test plan

- [x] `cargo check --package cipherbft-rpc` passes
- [x] All 50+ RPC tests pass
- [ ] Manual verification: Blockscout should sync successfully after node restart