### PR TITLE
fix: correct depth tracking in CallTracer only_top_call mode

### DIFF
--- a/crates/execution/src/inspector/call_tracer.rs
+++ b/crates/execution/src/inspector/call_tracer.rs
@@ -62,11 +62,12 @@ impl CallTracer {
 
     /// Push a new call frame onto the stack.
     fn push_frame(&mut self, frame: CallFrame) {
-        if self.config.only_top_call && self.depth > 0 {
+        self.depth += 1;
+        // When only_top_call is enabled, skip nested calls but still track depth
+        if self.config.only_top_call && self.depth > 1 {
             return;
         }
         self.call_stack.push(frame);
-        self.depth += 1;
     }
 
     /// Pop a call frame from the stack and attach it to the parent.


### PR DESCRIPTION
## Summary
- Fixed depth tracking bug in `CallTracer` when `only_top_call` is enabled
- Previously, nested calls would cause the root frame to be popped prematurely

## Problem
When `only_top_call` was enabled:
1. `push_frame` skipped nested calls **without** incrementing depth
2. `pop_frame` checked `depth > 1` which was false (depth stayed at 1)
3. This caused root frame to be popped when nested call ended

## Fix
Now depth is incremented **before** the early return check, so `pop_frame` correctly skips nested call endings.

## Test
- 3 line change in `crates/execution/src/inspector/call_tracer.rs`

Reported by @qj0r9j0vc2 in PR #115