### PR TITLE
fix: security and panic fixes (#127, #137)

### DIFF
--- a/crates/crypto/src/keystore/kdf.rs
+++ b/crates/crypto/src/keystore/kdf.rs
@@ -1,17 +1,16 @@
 //! Key Derivation Function (KDF) implementation
 //!
 //! Implements scrypt-based key derivation following EIP-2335 specification.
-//! Default parameters use fast settings (n=8192) for development.
-//! For production, consider using n=262144 (2^18) for stronger security.
+//! Default parameters use N=262144 (2^18) as per EIP-2335 standard.
 
 use serde::{Deserialize, Serialize};
 
 use super::error::{KeystoreError, KeystoreResult};
 use crate::secure::SecretBytes;
 
-/// Fast scrypt parameters for development (reduced from EIP-2335 standard)
-/// Production should use N=262144 (2^18) for stronger security
-pub const SCRYPT_N: u32 = 8192; // 2^13 - fast for development
+/// Standard scrypt parameters following EIP-2335 specification
+/// N=262144 (2^18) provides strong security for key derivation
+pub const SCRYPT_N: u32 = 262144; // 2^18 - EIP-2335 standard
 pub const SCRYPT_R: u32 = 8; // block size
 pub const SCRYPT_P: u32 = 1; // parallelization
 pub const SCRYPT_DKLEN: usize = 32; // derived key length

--- a/crates/node/src/node.rs
+++ b/crates/node/src/node.rs
@@ -855,7 +855,9 @@ impl Node {
         };
 
         // Start RPC server if enabled
-        if let (Some(ref storage), Some(ref debug_executor)) = (&rpc_storage, &rpc_debug_executor) {
+        if let (Some(ref storage), Some(ref debug_executor), Some(ref sub_mgr)) =
+            (&rpc_storage, &rpc_debug_executor, &subscription_manager)
+        {
             use cipherbft_rpc::{
                 RpcConfig, RpcServer, StubExecutionApi, StubMempoolApi, StubNetworkApi,
             };
@@ -879,7 +881,7 @@ impl Node {
                 executor,
                 network,
                 debug_executor.clone(),
-                subscription_manager.clone().unwrap(),
+                sub_mgr.clone(),
             );
 
             let http_port = self.config.rpc_http_port;


### PR DESCRIPTION
## Summary
- **#127**: Use EIP-2335 standard scrypt N=262144 instead of weak N=8192 for stronger key derivation security
- **#137**: Replace `subscription_manager.clone().unwrap()` with pattern matching to prevent potential panic

## Changes

### kdf.rs (Issue #127)
Changed scrypt parameter from N=8192 (2^13) to N=262144 (2^18) to follow EIP-2335 standard. This provides stronger security for key derivation.

### node.rs (Issue #137)
Changed the RPC server initialization from:
```rust
if let (Some(ref storage), Some(ref debug_executor)) = (&rpc_storage, &rpc_debug_executor) {
    // ...
    subscription_manager.clone().unwrap(),
}
```
to:
```rust
if let (Some(ref storage), Some(ref debug_executor), Some(ref sub_mgr)) =
    (&rpc_storage, &rpc_debug_executor, &subscription_manager)
{
    // ...
    sub_mgr.clone(),
}
```

This prevents a potential panic if subscription_manager is None.

## Test Plan
- [x] `cargo check` passes
- [x] `cargo test -p cipherbft-crypto --lib` passes (all 102 tests)

Closes #127
Closes #137