### PR TITLE
fix: WebSocket unwrap panic and use OsRng for crypto (#128, #130)

### DIFF
--- a/crates/crypto/src/keystore/cipher.rs
+++ b/crates/crypto/src/keystore/cipher.rs
@@ -182,11 +182,11 @@ pub fn decrypt_secret(
     Ok(secrecy::SecretBox::new(Box::new(plaintext)))
 }
 
-/// Generate a random IV
+/// Generate a random IV using OS random number generator
 pub fn generate_iv() -> Vec<u8> {
-    use rand::RngCore;
+    use rand::{rngs::OsRng, RngCore};
     let mut iv = vec![0u8; IV_LENGTH];
-    rand::thread_rng().fill_bytes(&mut iv);
+    OsRng.fill_bytes(&mut iv);
     iv
 }
 

--- a/crates/crypto/src/keystore/kdf.rs
+++ b/crates/crypto/src/keystore/kdf.rs
@@ -163,11 +163,11 @@ pub fn scrypt_derive_key(
     Ok(secrecy::SecretBox::new(Box::new(output)))
 }
 
-/// Generate a random salt
+/// Generate a random salt using OS random number generator
 pub fn generate_salt() -> Vec<u8> {
-    use rand::RngCore;
+    use rand::{rngs::OsRng, RngCore};
     let mut salt = vec![0u8; SALT_LENGTH];
-    rand::thread_rng().fill_bytes(&mut salt);
+    OsRng.fill_bytes(&mut salt);
     salt
 }
 

--- a/crates/rpc/src/pubsub.rs
+++ b/crates/rpc/src/pubsub.rs
@@ -295,7 +295,11 @@ impl EthPubSubRpcServer for EthPubSubApi {
                                 match result {
                                     Ok(block) => {
                                         let msg = serde_json::to_value(&*block).unwrap_or_default();
-                                        if sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await.is_err() {
+                                        let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
+                                            warn!("Failed to serialize block message for subscription {}", sub_id);
+                                            continue;
+                                        };
+                                        if sink.send(sub_msg).await.is_err() {
                                             trace!("Failed to send to subscription {}, closing", sub_id);
                                             manager.unsubscribe(sub_id);
                                             break;
@@ -332,7 +336,11 @@ impl EthPubSubRpcServer for EthPubSubApi {
                                         // Check if log matches the filter
                                         if matches_filter(&log, &log_filter) {
                                             let msg = serde_json::to_value(&*log).unwrap_or_default();
-                                            if sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await.is_err() {
+                                            let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
+                                                warn!("Failed to serialize log message for subscription {}", sub_id);
+                                                continue;
+                                            };
+                                            if sink.send(sub_msg).await.is_err() {
                                                 trace!("Failed to send to subscription {}, closing", sub_id);
                                                 manager.unsubscribe(sub_id);
                                                 break;
@@ -370,7 +378,11 @@ impl EthPubSubRpcServer for EthPubSubApi {
                                     match result {
                                         Ok(tx) => {
                                             let msg = serde_json::to_value(&*tx).unwrap_or_default();
-                                            if sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await.is_err() {
+                                            let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
+                                                warn!("Failed to serialize tx message for subscription {}", sub_id);
+                                                continue;
+                                            };
+                                            if sink.send(sub_msg).await.is_err() {
                                                 trace!("Failed to send to subscription {}, closing", sub_id);
                                                 manager.unsubscribe(sub_id);
                                                 break;
@@ -405,7 +417,11 @@ impl EthPubSubRpcServer for EthPubSubApi {
                                     match result {
                                         Ok(tx_hash) => {
                                             let msg = serde_json::to_value(tx_hash).unwrap_or_default();
-                                            if sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await.is_err() {
+                                            let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
+                                                warn!("Failed to serialize tx_hash message for subscription {}", sub_id);
+                                                continue;
+                                            };
+                                            if sink.send(sub_msg).await.is_err() {
                                                 trace!("Failed to send to subscription {}, closing", sub_id);
                                                 manager.unsubscribe(sub_id);
                                                 break;
@@ -443,7 +459,11 @@ impl EthPubSubRpcServer for EthPubSubApi {
                                         // Convert SyncStatus to JSON value
                                         // SyncStatus is an enum: None (not syncing) or Status(SyncInfo)
                                         let msg = serde_json::to_value(&status).unwrap_or_default();
-                                        if sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await.is_err() {
+                                        let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
+                                            warn!("Failed to serialize sync status message for subscription {}", sub_id);
+                                            continue;
+                                        };
+                                        if sink.send(sub_msg).await.is_err() {
                                             trace!("Failed to send to subscription {}, closing", sub_id);
                                             manager.unsubscribe(sub_id);
                                             break;


### PR DESCRIPTION
## Summary
- **#128**: Replace `.unwrap()` with proper error handling in WebSocket subscription handlers
- **#130**: Use `OsRng` instead of `thread_rng()` for cryptographic IV/salt generation

## Changes

### pubsub.rs (Issue #128)
Replaced 5 occurrences of panic-prone code:
```rust
// Before (can panic)
sink.send(jsonrpsee::SubscriptionMessage::from_json(&msg).unwrap()).await

// After (graceful error handling)
let Ok(sub_msg) = jsonrpsee::SubscriptionMessage::from_json(&msg) else {
    warn!("Failed to serialize message for subscription {}", sub_id);
    continue;
};
sink.send(sub_msg).await
```

### cipher.rs & kdf.rs (Issue #130)
Changed random number generator for cryptographic operations:
```rust
// Before
rand::thread_rng().fill_bytes(&mut data);

// After
OsRng.fill_bytes(&mut data);
```

`OsRng` directly uses the operating system's cryptographically secure random number generator, which is the recommended practice for generating cryptographic material like IVs and salts.

## Test Plan
- [x] `cargo check` passes

Closes #128
Closes #130