### PR TITLE
feat(cli): add --initial-balance-eth and setup-devnet.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ testnet/
 
 # Design plans (local only)
 docs/plans/
+
+# Docker auto-generated configs
+docker/configs/

--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -316,6 +316,10 @@ enum TestnetCommands {
         #[arg(long, default_value = "32")]
         initial_stake_eth: u64,
 
+        /// Initial balance per validator in ETH (for gas fees and transactions)
+        #[arg(long, default_value = "100")]
+        initial_balance_eth: u64,
+
         /// Starting P2P port (increments by 10 for each validator)
         #[arg(long, default_value = "9000")]
         starting_port: u16,
@@ -794,6 +798,7 @@ async fn cmd_testnet(command: TestnetCommands) -> Result<()> {
             chain_id,
             network_id,
             initial_stake_eth,
+            initial_balance_eth,
             starting_port,
             extra_alloc,
         } => cmd_testnet_init_files(
@@ -802,6 +807,7 @@ async fn cmd_testnet(command: TestnetCommands) -> Result<()> {
             chain_id,
             &network_id,
             initial_stake_eth,
+            initial_balance_eth,
             starting_port,
             extra_alloc,
         ),
@@ -812,12 +818,14 @@ async fn cmd_testnet(command: TestnetCommands) -> Result<()> {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn cmd_testnet_init_files(
     num_validators: usize,
     output: &std::path::Path,
     chain_id: u64,
     network_id: &str,
     initial_stake_eth: u64,
+    initial_balance_eth: u64,
     starting_port: u16,
     extra_alloc: Vec<String>,
 ) -> Result<()> {
@@ -856,12 +864,15 @@ fn cmd_testnet_init_files(
     }
 
     // Generate genesis with validators - this is our single source of truth for keys
-    let initial_stake = U256::from(initial_stake_eth) * U256::from(1_000_000_000_000_000_000u128);
+    let eth_to_wei = U256::from(1_000_000_000_000_000_000u128);
+    let initial_stake = U256::from(initial_stake_eth) * eth_to_wei;
+    let initial_balance = U256::from(initial_balance_eth) * eth_to_wei;
     let genesis_config = GenesisGeneratorConfig {
         num_validators,
         chain_id,
         network_id: network_id.to_string(),
         initial_stake,
+        initial_balance,
         extra_alloc: extra_alloc_parsed,
         ..Default::default()
     };

--- a/scripts/setup-devnet.sh
+++ b/scripts/setup-devnet.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# Setup devnet configuration with validator funding
+#
+# This script initializes a complete devnet environment including:
+# - Validator keys and configuration
+# - Genesis file with funded validator accounts
+# - Docker Compose configuration
+#
+# Usage:
+#   ./scripts/setup-devnet.sh [options]
+#
+# Options:
+#   -n, --validators <N>       Number of validators (default: 4)
+#   --stake <ETH>              Initial stake per validator in ETH (default: 32)
+#   --balance <ETH>            Initial balance per validator in ETH (default: 100)
+#   --chain-id <ID>            Chain ID (default: 85300)
+#   --network-id <ID>          Network identifier (default: cipherbft-devnet-1)
+#   --output <DIR>             Output directory (default: ./devnet)
+#   --extra-alloc <ADDR:ETH>   Extra account allocation (can be repeated)
+#   --force                    Overwrite existing devnet directory
+#   --help                     Show this help message
+#
+# Examples:
+#   ./scripts/setup-devnet.sh                                    # Default 4 validators, 100 ETH each
+#   ./scripts/setup-devnet.sh -n 7 --balance 1000                # 7 validators, 1000 ETH each
+#   ./scripts/setup-devnet.sh --extra-alloc 0x123...abc:5000     # Add extra funded account
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+
+# Default values
+NUM_VALIDATORS=4
+INITIAL_STAKE_ETH=32
+INITIAL_BALANCE_ETH=100
+CHAIN_ID=85300
+NETWORK_ID="cipherbft-devnet-1"
+OUTPUT_DIR="$PROJECT_ROOT/devnet"
+EXTRA_ALLOC=()
+FORCE=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -n|--validators)
+            NUM_VALIDATORS="$2"
+            shift 2
+            ;;
+        --stake)
+            INITIAL_STAKE_ETH="$2"
+            shift 2
+            ;;
+        --balance)
+            INITIAL_BALANCE_ETH="$2"
+            shift 2
+            ;;
+        --chain-id)
+            CHAIN_ID="$2"
+            shift 2
+            ;;
+        --network-id)
+            NETWORK_ID="$2"
+            shift 2
+            ;;
+        -o|--output)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --extra-alloc)
+            EXTRA_ALLOC+=("--extra-alloc" "$2")
+            shift 2
+            ;;
+        --force)
+            FORCE=true
+            shift
+            ;;
+        -h|--help)
+            sed -n '2,27p' "$0" | sed 's/^# //' | sed 's/^#//'
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+# Check if output directory exists
+if [ -d "$OUTPUT_DIR" ]; then
+    if [ "$FORCE" = true ]; then
+        echo "Removing existing devnet directory: $OUTPUT_DIR"
+        rm -rf "$OUTPUT_DIR"
+    else
+        echo "Error: Devnet directory already exists: $OUTPUT_DIR"
+        echo ""
+        echo "Options:"
+        echo "  - Use --force to overwrite"
+        echo "  - Use --output to specify a different directory"
+        echo "  - Use ./scripts/reset-devnet.sh to reset state while keeping keys"
+        exit 1
+    fi
+fi
+
+echo "Setting up devnet with $NUM_VALIDATORS validators..."
+echo ""
+echo "Configuration:"
+echo "  Validators:       $NUM_VALIDATORS"
+echo "  Initial Stake:    $INITIAL_STAKE_ETH ETH per validator"
+echo "  Initial Balance:  $INITIAL_BALANCE_ETH ETH per validator"
+echo "  Chain ID:         $CHAIN_ID"
+echo "  Network ID:       $NETWORK_ID"
+echo "  Output:           $OUTPUT_DIR"
+if [ ${#EXTRA_ALLOC[@]} -gt 0 ]; then
+    echo "  Extra Allocs:     ${EXTRA_ALLOC[*]}"
+fi
+echo ""
+
+# Build the CLI if needed
+echo "Building cipherd..."
+cargo build -p cipherd --release 2>&1 | grep -E "(Compiling|Finished)" || true
+echo ""
+
+# Find the binary
+CIPHERD_BIN="$PROJECT_ROOT/target/release/cipherd"
+if [ ! -f "$CIPHERD_BIN" ]; then
+    CIPHERD_BIN="$PROJECT_ROOT/target/debug/cipherd"
+fi
+
+if [ ! -f "$CIPHERD_BIN" ]; then
+    echo "Error: cipherd binary not found. Build failed?"
+    exit 1
+fi
+
+# Run devnet init-files with our configuration
+echo "Generating devnet configuration..."
+"$CIPHERD_BIN" devnet init-files \
+    --validators "$NUM_VALIDATORS" \
+    --output "$OUTPUT_DIR" \
+    --chain-id "$CHAIN_ID" \
+    --network-id "$NETWORK_ID" \
+    --initial-stake-eth "$INITIAL_STAKE_ETH" \
+    --initial-balance-eth "$INITIAL_BALANCE_ETH" \
+    "${EXTRA_ALLOC[@]}"
+
+echo ""
+
+# Generate docker-compose configuration
+echo "Generating Docker Compose configuration..."
+"$SCRIPT_DIR/generate-compose.sh" "$OUTPUT_DIR" "$PROJECT_ROOT/docker"
+
+echo ""
+echo "Devnet setup complete!"
+echo ""
+echo "Validator accounts funded with:"
+echo "  - $INITIAL_STAKE_ETH ETH staked in deposit contract"
+echo "  - $INITIAL_BALANCE_ETH ETH available balance (for gas)"
+echo ""
+echo "Next steps:"
+echo "  Start devnet:  ./scripts/start-devnet.sh"
+echo "  Reset state:   ./scripts/reset-devnet.sh"
+echo "  Stop devnet:   ./scripts/stop-devnet.sh"
+echo ""
+echo "RPC endpoints (after start):"
+for ((i=0; i<NUM_VALIDATORS; i++)); do
+    PORT=$((8545 + i * 10))
+    echo "  node$i: http://localhost:$PORT"
+done


### PR DESCRIPTION
## Summary
- Add `--initial-balance-eth` CLI flag to configure validator account balance (separate from stake)
- Create `setup-devnet.sh` script for convenient devnet initialization with configurable funding

## Changes
- **CLI**: New `--initial-balance-eth` flag on `devnet init-files` command (default: 100 ETH)
- **Script**: `scripts/setup-devnet.sh` wraps devnet initialization with proper options

## Usage

```bash
# Setup devnet with default 100 ETH balance per validator
./scripts/setup-devnet.sh

# Setup with custom balance (e.g., 1000 ETH)
./scripts/setup-devnet.sh --balance 1000 -n 4

# Show all options
./scripts/setup-devnet.sh --help
```

## Test Plan
- [x] Verified `--initial-balance-eth` flag appears in CLI help
- [x] Tested setup-devnet.sh creates genesis with correct balances
- [x] All existing tests pass