### PR TITLE
feat(rpc): implement real RPC methods replacing stubs

### DIFF
--- a/crates/node/src/execution_bridge.rs
+++ b/crates/node/src/execution_bridge.rs
@@ -7,7 +7,7 @@ use cipherbft_data_chain::worker::TransactionValidator;
 use cipherbft_execution::{
     keccak256, BlockInput, Bytes, Car as ExecutionCar, ChainConfig, Cut as ExecutionCut,
     ExecutionEngine, ExecutionLayerTrait, ExecutionResult, GenesisInitializer,
-    GenesisValidatorData, InMemoryProvider, B256, U256,
+    GenesisValidatorData, InMemoryProvider, StakingPrecompile, B256, U256,
 };
 use cipherbft_storage::DclStore;
 use cipherbft_types::genesis::Genesis;
@@ -443,6 +443,17 @@ impl ExecutionBridge {
     pub async fn provider(&self) -> Arc<InMemoryProvider> {
         let execution = self.execution.read().await;
         execution.provider()
+    }
+
+    /// Get a reference to the staking precompile.
+    ///
+    /// This allows sharing the staking precompile with the RPC layer so that
+    /// `eth_call` to address 0x100 can query the same validator state as the
+    /// execution layer. This is essential for RPC queries about validators,
+    /// stakes, and rewards.
+    pub async fn staking_precompile(&self) -> Arc<StakingPrecompile> {
+        let execution = self.execution.read().await;
+        Arc::clone(execution.staking_precompile())
     }
 }
 

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -10,6 +10,7 @@ pub mod execution_bridge;
 pub mod genesis_bootstrap;
 pub mod key_cli;
 pub mod network;
+pub mod network_api;
 pub mod node;
 pub mod supervisor;
 pub mod util;
@@ -27,5 +28,6 @@ pub use genesis_bootstrap::{
     GenesisLoader, ValidatorKeyFile,
 };
 pub use key_cli::{execute_keys_command, KeysCommand};
+pub use network_api::{NodeNetworkApi, TcpNetworkApi};
 pub use node::Node;
 pub use supervisor::{NodeSupervisor, ShutdownError};

--- a/crates/node/src/network_api.rs
+++ b/crates/node/src/network_api.rs
@@ -1,0 +1,71 @@
+//! Real NetworkApi implementation backed by TcpPrimaryNetwork.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use cipherbft_rpc::{NetworkApi, RpcResult, StubNetworkApi};
+
+use crate::network::TcpPrimaryNetwork;
+
+/// Real NetworkApi backed by TcpPrimaryNetwork.
+pub struct TcpNetworkApi {
+    network: Arc<TcpPrimaryNetwork>,
+}
+
+impl TcpNetworkApi {
+    /// Create a new TcpNetworkApi wrapping the given network.
+    pub fn new(network: Arc<TcpPrimaryNetwork>) -> Self {
+        Self { network }
+    }
+}
+
+#[async_trait]
+impl NetworkApi for TcpNetworkApi {
+    async fn peer_count(&self) -> RpcResult<u64> {
+        Ok(self.network.connected_peer_count().await as u64)
+    }
+
+    async fn is_listening(&self) -> RpcResult<bool> {
+        Ok(self.network.is_listening())
+    }
+}
+
+/// Unified NetworkApi that can be either real (TcpNetworkApi) or stub.
+///
+/// This enum allows the RpcServer to use a single concrete type while
+/// supporting both DCL-enabled and DCL-disabled configurations.
+pub enum NodeNetworkApi {
+    /// Real implementation backed by TcpPrimaryNetwork (DCL enabled)
+    Tcp(TcpNetworkApi),
+    /// Stub implementation (DCL disabled)
+    Stub(StubNetworkApi),
+}
+
+impl NodeNetworkApi {
+    /// Create a real NetworkApi backed by TcpPrimaryNetwork.
+    pub fn tcp(network: Arc<TcpPrimaryNetwork>) -> Self {
+        Self::Tcp(TcpNetworkApi::new(network))
+    }
+
+    /// Create a stub NetworkApi.
+    pub fn stub() -> Self {
+        Self::Stub(StubNetworkApi::new())
+    }
+}
+
+#[async_trait]
+impl NetworkApi for NodeNetworkApi {
+    async fn peer_count(&self) -> RpcResult<u64> {
+        match self {
+            Self::Tcp(api) => api.peer_count().await,
+            Self::Stub(api) => api.peer_count().await,
+        }
+    }
+
+    async fn is_listening(&self) -> RpcResult<bool> {
+        match self {
+            Self::Tcp(api) => api.is_listening().await,
+            Self::Stub(api) => api.is_listening().await,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add staking precompile to EvmExecutionApi for eth_call at address 0x100
- Wire MdbxLogStore to enable eth_getLogs
- Implement dynamic eth_maxPriorityFeePerGas from mempool
- Implement dynamic eth_gasPrice using computed priority fee
- Compute eth_feeHistory reward percentiles from block receipts
- Add TcpNetworkApi for real net_peerCount and net_listening
- Handle block parameter validation in eth_call/eth_estimateGas

## Test plan
- [x] cargo check --workspace passes
- [x] cargo test -p cipherbft-rpc all tests pass
- [x] cargo clippy -D warnings no warnings