### PR TITLE
fix(rpc): handle duplicate data/input fields in CallRequest

### DIFF
--- a/crates/rpc/src/debug/mod.rs
+++ b/crates/rpc/src/debug/mod.rs
@@ -197,7 +197,7 @@ where
                 call_request.gas.map(|g| g.to::<u64>()),
                 call_request.gas_price,
                 call_request.value,
-                call_request.data,
+                call_request.input_data(),
                 block_num,
                 options,
             )


### PR DESCRIPTION
Fixes JSON-RPC error when clients send both data and input fields in eth_call/eth_estimateGas requests.