### PR TITLE
fix(evm): set chain_id in TxEnv for eth_call and eth_estimateGas

### DIFF
--- a/crates/execution/src/evm.rs
+++ b/crates/execution/src/evm.rs
@@ -1,7 +1,7 @@
 //! EVM configuration and transaction execution.
 //!
 //! This module provides the EVM setup for CipherBFT, including:
-//! - Chain configuration (Chain ID 31337)
+//! - Chain configuration (Chain ID 85300)
 //! - Staking precompile at address 0x100
 //! - Transaction execution with revm
 //! - Environment configuration (block, tx, cfg)
@@ -19,10 +19,8 @@ use revm::{
     primitives::{hardfork::SpecId, TxKind},
 };
 
-/// CipherBFT Chain ID (31337 - Ethereum testnet/development chain ID).
-///
-/// This can be configured for different networks but defaults to 31337.
-pub const CIPHERBFT_CHAIN_ID: u64 = 31337;
+/// CipherBFT Chain ID (85300).
+pub const CIPHERBFT_CHAIN_ID: u64 = 85300;
 
 /// Default block gas limit (30 million gas).
 pub const DEFAULT_BLOCK_GAS_LIMIT: u64 = 30_000_000;
@@ -555,7 +553,8 @@ mod tests {
 
     #[test]
     fn test_constants() {
-        assert_eq!(CIPHERBFT_CHAIN_ID, 31337);
+        // CipherBFT Testnet chain ID (matches ChainConfig::default() and genesis.json)
+        assert_eq!(CIPHERBFT_CHAIN_ID, 85300);
         assert_eq!(
             STAKING_PRECOMPILE_ADDRESS,
             Address::from_str("0x0000000000000000000000000000000000000100").unwrap()

--- a/crates/rpc/src/adapters.rs
+++ b/crates/rpc/src/adapters.rs
@@ -1961,6 +1961,7 @@ impl<P: Provider> EvmExecutionApi<P> {
         ctx.tx.value = value.unwrap_or(U256::ZERO);
         ctx.tx.data = data.unwrap_or_default();
         ctx.tx.nonce = 0; // For calls, nonce doesn't matter
+        ctx.tx.chain_id = Some(self.chain_id); // Required for EIP-155 validation
 
         // Build the EVM with CipherBFT precompiles (includes staking at 0x100)
         let precompiles =


### PR DESCRIPTION
Fix InvalidChainId error in eth_estimateGas and eth_call by setting ctx.tx.chain_id in execute_call_internal. Also update CIPHERBFT_CHAIN_ID constant from 31337 to 85300.