### PR TITLE
fix: disable nonce check for eth_call and eth_estimateGas simulations

### DIFF
--- a/crates/rpc/src/adapters.rs
+++ b/crates/rpc/src/adapters.rs
@@ -2189,6 +2189,9 @@ impl<P: Provider> EvmExecutionApi<P> {
 
         // Configure chain settings
         ctx.cfg.chain_id = self.chain_id;
+        // For eth_call/eth_estimateGas, disable nonce check
+        // These are simulation calls that shouldn't enforce nonce validity
+        ctx.cfg.disable_nonce_check = true;
 
         // Set up transaction environment
         ctx.tx.caller = from.unwrap_or(Address::ZERO);
@@ -2647,6 +2650,8 @@ where
 
         // Configure chain settings
         ctx.cfg.chain_id = self.chain_id;
+        // For tracing/debug calls, disable nonce check
+        ctx.cfg.disable_nonce_check = true;
 
         // Set up transaction environment
         ctx.tx.caller = from.unwrap_or(Address::ZERO);
@@ -2757,6 +2762,8 @@ where
 
         // Configure chain settings
         ctx.cfg.chain_id = self.chain_id;
+        // For tracing/debug calls, disable nonce check
+        ctx.cfg.disable_nonce_check = true;
 
         // Set up transaction environment
         ctx.tx.caller = from.unwrap_or(Address::ZERO);


### PR DESCRIPTION
## Summary
- Disable nonce validation for eth_call, eth_estimateGas, and debug tracing calls
- Fixes NonceTooLow error that occurs after first transaction when using cast send

## Problem
After the first transaction, subsequent eth_estimateGas calls fail with:
```
EVM execution failed: Transaction(NonceTooLow { tx: 0, state: 1 })
```

This happens because simulation calls hardcode `nonce = 0` but don't disable nonce checking in the EVM.

## Solution
Set `ctx.cfg.disable_nonce_check = true` for all EVM simulation contexts, matching reth/geth behavior.