### PR TITLE
fix: add missing attestation_quorum arg

### DIFF
--- a/crates/data-chain/src/primary/runner.rs
+++ b/crates/data-chain/src/primary/runner.rs
@@ -724,7 +724,7 @@ impl Primary {
                 );
 
                 // Update cut former with new validator list
-                self.cut_former = CutFormer::new(validators);
+                self.cut_former = CutFormer::new(validators, self.config.attestation_quorum);
 
                 info!(
                     validator = %self.config.validator_id,


### PR DESCRIPTION
## Summary
- Fix compilation error in `CutFormer::new` call at `runner.rs:727`
- Add missing `attestation_quorum` parameter to match constructor signature

## Test plan
- [x] `cargo check -p cipherbft-data-chain` passes
- [x] `cargo test -p cipherbft-data-chain` passes (124 tests)