### PR TITLE
feat: bump initial validator balance to 100k CPH

### DIFF
--- a/crates/node/src/genesis_bootstrap.rs
+++ b/crates/node/src/genesis_bootstrap.rs
@@ -227,8 +227,8 @@ impl Default for GenesisGeneratorConfig {
             network_id: "cipherbft-testnet-1".to_string(),
             // 32 CPH = 32 * 10^18 wei = 0x1bc16d674ec80000
             initial_stake: U256::from(32_000_000_000_000_000_000u128),
-            // 100 CPH = 100 * 10^18 wei
-            initial_balance: U256::from(100_000_000_000_000_000_000u128),
+            // 100,000 CPH = 100,000 * 10^18 wei
+            initial_balance: U256::from(100_000_000_000_000_000_000_000u128),
             gas_limit: U256::from(30_000_000u64),
             extra_alloc: Vec::new(),
         }
@@ -497,7 +497,7 @@ impl GenesisGenerator {
     ///     85300,
     ///     "cipherbft-testnet-1",
     ///     32_000_000_000_000_000_000u128.into(),  // 32 CPH
-    ///     100_000_000_000_000_000_000u128.into(), // 100 CPH
+    ///     100_000_000_000_000_000_000_000u128.into(), // 100,000 CPH
     /// )?;
     /// ```
     pub fn generate_from_validator_keys(
@@ -1001,10 +1001,10 @@ mod tests {
             config.initial_stake,
             U256::from(32_000_000_000_000_000_000u128)
         );
-        // 100 CPH in wei
+        // 100,000 CPH in wei
         assert_eq!(
             config.initial_balance,
-            U256::from(100_000_000_000_000_000_000u128)
+            U256::from(100_000_000_000_000_000_000_000u128)
         );
         // 30M gas
         assert_eq!(config.gas_limit, U256::from(30_000_000u64));

--- a/crates/node/tests/cli_extra_alloc.rs
+++ b/crates/node/tests/cli_extra_alloc.rs
@@ -119,11 +119,11 @@ fn test_genesis_generate_extra_alloc_balance_conversion() {
         .get("0x3e54b36f4f8efaa017888e66fb6db17098437ac7")
         .unwrap();
 
-    // 100 ETH = 100 * 10^18 wei = 0x56bc75e2d63100000
+    // 100 CPH = 100 * 10^18 wei = 0x56bc75e2d63100000
     let balance = entry["balance"].as_str().unwrap();
     assert_eq!(
         balance, "0x56bc75e2d63100000",
-        "Expected 100 ETH in wei (hex)"
+        "Expected 100 CPH in wei (hex)"
     );
 }
 

--- a/devnet/genesis.json
+++ b/devnet/genesis.json
@@ -16,13 +16,13 @@
   },
   "alloc": {
     "0x70997970c51812dc3a010c7d01b50e0d17dc79c8": {
-      "balance": "0x56bc75e2d63100000"
+      "balance": "0x152d02c7e14af6800000"
     },
     "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266": {
-      "balance": "0x56bc75e2d63100000"
+      "balance": "0x152d02c7e14af6800000"
     },
     "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc": {
-      "balance": "0x56bc75e2d63100000"
+      "balance": "0x152d02c7e14af6800000"
     }
   },
   "gasLimit": "0x1c9c380",


### PR DESCRIPTION
## Summary
- Update default initial validator balance from 100 CPH to 100,000 CPH
- Update devnet genesis.json alloc balances accordingly
- Fix ETH → CPH naming in test comment

## Test plan
- [x] `cargo build` passes
- [x] `cargo test -p cipherd` — 110 tests pass
- [x] `cargo test -p cipherbft-execution` — 217 tests pass
- [x] `cargo test -p cipherbft-types` — 42 tests pass